### PR TITLE
Default Nginx version comes from semver

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,12 +15,15 @@ BUILD_DIR="$1"
 CACHE_DIR="$2"
 export_env_dir "$3"
 
-NGINX_VERSION=${NGINX_VERSION:-1.17.6}
 SWIFT_BUCKET=${NGINX_BP_SWIFT_BUCKET:-scalingo-php-buildpack}
 SWIFT_BASE_URL=${NGINX_BP_SWIFT_URL:-https://storage.sbg1.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a419eac98613f2}
 STACK="${STACK:-scalingo-18}"
 SWIFT_URL="${SWIFT_BASE_URL}/${SWIFT_BUCKET}/${STACK}"
 LOG_FILES=(vendor/nginx/logs/access.log vendor/nginx/logs/error.log)
+
+SEMVER_SERVER="https://semver.scalingo.io"
+DEFAULT_NGINX=$(curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}")
+NGINX_VERSION=${NGINX_VERSION:-$DEFAULT_NGINX}
 
 mkdir -p "$CACHE_DIR/package"
 
@@ -35,7 +38,7 @@ if [ ! -d "$BUILD_DIR/vendor" ] ; then
 fi
 
 VENDORED_NGINX=/app/vendor/nginx
-status "Bundling NGINX ${NGINX_VERSION}"
+status "Bundling Nginx ${NGINX_VERSION}"
 fetch_engine_package nginx "$NGINX_VERSION" "${VENDORED_NGINX}" | indent
 
 test ! -d "$BUILD_DIR/.profile.d" && mkdir -p "$BUILD_DIR/.profile.d" || true


### PR DESCRIPTION
```
 <-- Start deployment of etienne-default-nginx -->
       Fetching source code
       Fetching deployment cache
-----> Cloning custom buildpack: https://github.com/Scalingo/nginx-buildpack.git#fix/php/120/default_nginx
-----> Bundling Nginx 1.16.1
       Checksums match. Fetching from cache.
```

Fix https://github.com/Scalingo/php-buildpack/issues/120

Same code as in https://github.com/Scalingo/php-buildpack/pull/121