### PR TITLE
Remove "Advanced Information" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,3 @@ server {
     }
 }
 ```
-
-## Advanced Information
-
-The configuration file you have to provide is at the `server` level, if you need
-to add something at the `http` level, please open an [issue](https://github.com/Scalingo/nginx-buildpack/issues/new)
-or a [pull request](https://github.com/Scalingo/nginx-buildpack/pulls/new) and we'll discuss it.


### PR DESCRIPTION
With the introduction of `servers.conf.erb` it is no longer true that configuration cannot be done at the `http` level.