### PR TITLE
Log request_time by default

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -15,7 +15,7 @@ http {
     keepalive_timeout  65;
 
     log_format specialLog '$http_x_forwarded_for - '
-                      '"$request" $status $body_bytes_sent '
+                      '"$request" $status $body_bytes_sent $request_time '
                       '"$http_referer" "$http_user_agent"';
 
     error_log logs/error.log notice;


### PR DESCRIPTION
→ Information is important and not displayed anywhere
→ It was asked by a customer

Example:

```
2020-12-16 16:53:16.317047285 +0100 CET [web-1] 93.25.171.231 - "GET / HTTP/1.1" 200 2 0.000 "-" "curl/7.68.0"
2020-12-16 16:53:16.317068713 +0100 CET [web-1] 93.25.171.231 - "GET / HTTP/1.1" 200 2 0.000 "-" "curl/7.68.0"
2020-12-16 16:53:17.317509104 +0100 CET [web-1] 93.25.171.231 - "GET / HTTP/1.1" 200 2 0.000 "-" "curl/7.68.0"
```

Fixes #18