### PR TITLE
chore(nginx-buildpack): update ModSecurity to 3.0.9

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,4 +1,4 @@
 default_zlib_version="1.2.13"
 default_nginx_version="1.22.1"
-default_modsecurity_version="3.0.8"
+default_modsecurity_version="3.0.9"
 default_modsecurity_coreruleset_version="3.3.4"


### PR DESCRIPTION
Files have been uploaded to ObjectStorage for:
- `scalingo-20`
- `scalingo-20-minimal`
- `scalingo-22`
- `scalingo-22-minimal`