### PR TITLE
chore(modsecurity): upgrade from 3.0.9 to 3.0.10

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,5 +1,5 @@
 default_zlib_version="1.2.13"
 default_nginx_version="1.22.1"
-default_modsecurity_version="3.0.9"
+default_modsecurity_version="3.0.10"
 default_modsecurity_nginx_version="1.0.3"
 default_modsecurity_coreruleset_version="3.3.4"


### PR DESCRIPTION
Files have been uploaded to ObjectStorage for:
- `scalingo-20`
- `scalingo-20-minimal`
- `scalingo-22`
- `scalingo-22-minimal`

Fixes #45 