### PR TITLE
Permettre d'utiliser php-buildpack et nginx-buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,8 @@ SH
 source "$BUILD_DIR/.profile.d/nginx.sh"
 
 cp "$basedir/../config/nginx.conf.erb" "$BUILD_DIR/base_nginx.conf.erb"
-mv /app/vendor/nginx "$BUILD_DIR/vendor"
+[ ! -f $BUILD_DIR/vendor/nginx ]
+  mv /app/vendor/nginx "$BUILD_DIR/vendor"
 
 if [ "$ENABLE_MODSECURITY" = "true" ] ; then
   VENDORED_MODSECURITY=/app/vendor/modsecurity

--- a/bin/compile
+++ b/bin/compile
@@ -108,6 +108,10 @@ fi
 `tail_log_plex ${LOG_FILES[@]}`
 
 (
+    php-fpm -p "/app/vendor/php"
+    echo "php-fpm" > \$pmsgr
+) &
+(
     nginx -p "\$basedir/vendor/nginx" -c "\$basedir/vendor/nginx/conf/nginx.conf"
     echo "nginx" > \$pmsgr
 ) &

--- a/bin/compile
+++ b/bin/compile
@@ -85,6 +85,12 @@ pmsgr=/tmp/pmsgr
 rm -f \$pmsgr
 mkfifo \$pmsgr
 
+# Loop through all environment variables. Work even though there are multi-lines
+# env variables.
+env -0 | while IFS='=' read -r -d '' name value; do
+    echo "env[\$name] = \\$\${name}" >> /app/vendor/php/etc/php-fpm.conf
+done
+
 [ -f \$basedir/servers.conf.erb ] && export HAS_SERVER_CONF=true
 
 if [ -f "\$basedir/base_nginx.conf.erb" ] ; then

--- a/bin/compile
+++ b/bin/compile
@@ -49,8 +49,10 @@ SH
 source "$BUILD_DIR/.profile.d/nginx.sh"
 
 cp "$basedir/../config/nginx.conf.erb" "$BUILD_DIR/base_nginx.conf.erb"
-[ ! -f $BUILD_DIR/vendor/nginx ]
+
+if [ ! -d "$BUILD_DIR/vendor/nginx" ] ; then
   mv /app/vendor/nginx "$BUILD_DIR/vendor"
+fi
 
 if [ "$ENABLE_MODSECURITY" = "true" ] ; then
   VENDORED_MODSECURITY=/app/vendor/modsecurity

--- a/bin/compile
+++ b/bin/compile
@@ -87,7 +87,11 @@ mkfifo \$pmsgr
 
 [ -f \$basedir/servers.conf.erb ] && export HAS_SERVER_CONF=true
 
-erb base_nginx.conf.erb > "\$basedir/vendor/nginx/conf/nginx.conf"
+if [ -f "\$basedir/base_nginx.conf.erb" ] ; then
+  erb "\$basedir/base_nginx.conf.erb" > "\$basedir/vendor/nginx/conf/nginx.conf"
+else
+  erb base_nginx.conf.erb > "\$basedir/vendor/nginx/conf/nginx.conf"
+fi
 
 if [ -f "\$basedir/nginx.conf.erb" ] ; then
   erb "\$basedir/nginx.conf.erb" > "\$basedir/vendor/nginx/conf/site.conf"

--- a/bin/compile
+++ b/bin/compile
@@ -107,6 +107,32 @@ fi
 `init_log_plex ${LOG_FILES[@]}`
 `tail_log_plex ${LOG_FILES[@]}`
 
+if [[ -z \${WEB_CONCURRENCY:-} ]]; then
+    ram="512M"
+    container_size=\${CONTAINER_SIZE:-M}
+    if [ \$container_size = "S" ] ; then
+        ram="256M"
+    elif [ \$container_size = "L" ] ; then
+        ram="1024M"
+    elif [ \$container_size = "XL" ] ; then
+        ram="2048M"
+    elif [ \$container_size = "2XL" ] ; then
+        ram="4096M"
+    elif [ \$container_size = "3XL" ] ; then
+        ram="8182M"
+    fi
+
+    echo "Optimizing defaults for \${container_size} container..." >&2
+
+    # determine number of FPM processes to run
+    read WEB_CONCURRENCY php_memory_limit <<<\$(php -c "/app/vendor/php/etc/php.ini" /app/conf/autotune.php -y "/app/vendor/php/etc/php-fpm.conf" -t "\$DOCUMENT_ROOT" "\$ram")
+    [[ \$WEB_CONCURRENCY -lt 3 ]] && WEB_CONCURRENCY=3
+    export WEB_CONCURRENCY
+    echo "\${WEB_CONCURRENCY} processes at \${php_memory_limit}B memory limit." >&2
+else
+    echo "Using WEB_CONCURRENCY=\${WEB_CONCURRENCY} processes." >&2
+fi
+
 (
     php-fpm -p "/app/vendor/php"
     echo "php-fpm" > \$pmsgr


### PR DESCRIPTION
Bonjour.
Voici un autre exemple qui permet d'éviter de toucher au php buildpack pour que le multidomaine fonctionne.
Je ne crois pas que la solution soit beaucoup mieux, car ça fait ajouter des spécificités PHP dans un buildpack nginx.

La solution idéal serait peut-être d'avoir un php-buildpack sans nginx, qui se contenterait de faire son travail de php.
Mais, ça fait 2 buildpack à maintenir.

Finalement, le premier pull request n'est peut être pas si mal.
Même si je comprends votre logique.

J'attends vos instructions, car rester sur une logique ou je dois maintenir mon buildpack-php ne me rassure pas.

Merci