### PR TITLE
chore(mod_security): update ModSecurity from 3.0.11 to 3.0.12

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,5 +1,5 @@
 default_zlib_version="1.2.13"
 default_nginx_version="1.22.1"
-default_modsecurity_version="3.0.11"
+default_modsecurity_version="3.0.12"
 default_modsecurity_nginx_version="1.0.3"
 default_modsecurity_coreruleset_version="3.3.4"


### PR DESCRIPTION
Packages have been built and uploaded on ObjectStorage for:
- `scalingo-20`
- `scalingo-20-minimal`
- `scalingo-22`
- `scalingo-22-minimal`

Fix #50