### PR TITLE
feat: set default Nginx version to 1.26.1

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,5 +1,5 @@
 default_zlib_version="1.2.13"
-default_nginx_version="1.22.1"
+default_nginx_version="1.26.1"
 default_modsecurity_version="3.0.12"
 default_modsecurity_nginx_version="1.0.3"
 default_modsecurity_coreruleset_version="3.3.4"


### PR DESCRIPTION
Files have been uploaded to ObjectStorage for both `scalingo-20` and `scalingo-22`.
Related to #52