### PR TITLE
chore: update nginx default version to 1.26.3

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,5 +1,5 @@
-default_zlib_version="1.2.13"
-default_nginx_version="1.26.1"
+default_zlib_version="1.3.1"
+default_nginx_version="1.26.3"
 default_modsecurity_version="3.0.13"
 default_modsecurity_nginx_version="1.0.3"
-default_modsecurity_coreruleset_version="4.10.0"
+default_modsecurity_coreruleset_version="4.11.0"

--- a/support/lib/utils
+++ b/support/lib/utils
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 
 function validate_env() {
-    if [ -z "$S3_BUCKET" ]; then
-      echo "Must set S3_BUCKET environment variable" >&2
-      exit 1
-    fi
+	if [ -z "$S3_BUCKET" ]; then
+		echo "Must set S3_BUCKET environment variable" >&2
+		exit 1
+	fi
 
-    if [[ -z "$AWS_ACCESS_KEY_ID" \
-            || -z "${AWS_SECRET_ACCESS_KEY}" \
-            || -z "${AWS_SESSION_TOKEN}" ]]
-    then
-        echo "Please export AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN from AWS console." >&2
-        exit 1
-    fi
+	if [[ -z "$AWS_ACCESS_KEY_ID" \
+			|| -z "${AWS_SECRET_ACCESS_KEY}" \
+			|| -z "${AWS_SESSION_TOKEN}" ]]
+	then
+		echo "Please export AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN from AWS console." >&2
+		exit 1
+	fi
 }
 
 function mktmpdir() {
-    tempdir="$( mktemp -t $1_XXXX )"
-    rm -rf "${tempdir}"
-    mkdir -p "${tempdir}"
-    echo "${tempdir}"
+	tempdir="$( mktemp -t $1_XXXX )"
+	rm -rf "${tempdir}"
+	mkdir -p "${tempdir}"
+	echo "${tempdir}"
 }
 
 function md5() {
-    md5sum $1 | awk '{print $1}'
+	md5sum $1 | awk '{print $1}'
 }

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -26,6 +26,8 @@ zlib_version="$default_zlib_version"
 
 validate_env
 
+which aws >/dev/null || apt-get install awscli
+
 export PATH=${basedir}/../vendor/bin:$PATH
 
 if [ -z "$nginx_version" ]; then


### PR DESCRIPTION
- nginx default version is updated to `1.26.3`
- zlib is updated to `1.3.1`
- ModSecurity Core Rule Set is updated to `4.11.0`

Related to https://github.com/Scalingo/nginx-buildpack/issues/78
Related to https://github.com/Scalingo/nginx-buildpack/issues/77