### PR TITLE
fix(manifest): fix manifest scripts

### DIFF
--- a/support/manifest
+++ b/support/manifest
@@ -26,26 +26,26 @@ validate_env
 
 # make a temp directory
 tempdir=$(mktmpdir manifest)
-pushd $tempdir > /dev/null
 
 echo "-----> Manifest for $manifest_type"
 
+manifest_file="manifest.${manifest_type}"
+
 s3_list "$S3_BUCKET" "${STACK}/package/" \
 	| jq -r ".Contents[].Key" \
-    | sed "s/^.\+$STACK\/package\///" \
-    | grep "\.tgz$" \
-    | grep "^${manifest_type}" \
-    | grep -v -e ".md5" \
-    | sed -e "s/${manifest_type}-\([0-9.]*\)\\.tgz/\\1/" \
-    | awk 'BEGIN {FS="."} {printf("%03d.%03d.%03d %s\n",$1,$2,$3,$0)}' \
-    | sort -r \
-    | cut -d" " -f2 \
-    > manifest.${manifest_type}
+	| sed "s/${STACK}\/package\///" \
+	| grep "\.tgz$" \
+	| grep "^${manifest_type}" \
+	| grep -v -e ".md5" \
+	| sed -e "s/${manifest_type}-\([0-9.]*\)\\.tgz/\\1/" \
+	| awk 'BEGIN {FS="."} {printf("%03d.%03d.%03d %s\n",$1,$2,$3,$0)}' \
+	| sort -r \
+	| cut -d" " -f2 \
+	> "${tempdir}/${manifest_file}"
 
-cat "manifest.${manifest_type}" | indent
+cat "${tempdir}/${manifest_file}" | indent
 
 echo
-echo "-----> Uploading manifest for ${manifest_type} to S3"
+echo "-----> Uploading manifest to S3"
 
-manifest_filename="manifest.${manifest_type}"
-s3_upload "$S3_BUCKET" "$manifest_filename" "${STACK}/${manifest_filename}"
+s3_upload "$S3_BUCKET" "${tempdir}/${manifest_file}" "${STACK}/${manifest_file}"

--- a/support/manifest
+++ b/support/manifest
@@ -25,7 +25,7 @@ fi
 validate_env
 
 # make a temp directory
-tempdir=$(mktmpdir manifest)
+tempdir="$( mktmpdir manifest )"
 
 echo "-----> Manifest for $manifest_type"
 
@@ -43,9 +43,15 @@ s3_list "$S3_BUCKET" "${STACK}/package/" \
 	| cut -d" " -f2 \
 	> "${tempdir}/${manifest_file}"
 
+if [ ! -s "${tempdir}/${manifest_file}" ]; then
+	echo "The manifest that has juts been generated is empty." >&2
+	echo "This is not OK. Aborting." >&2
+	exit 2
+fi
+
 cat "${tempdir}/${manifest_file}" | indent
 
 echo
 echo "-----> Uploading manifest to S3"
 
-s3_upload "$S3_BUCKET" "${tempdir}/${manifest_file}" "${STACK}/${manifest_file}"
+s3_upload "${S3_BUCKET}" "${tempdir}/${manifest_file}" "${STACK}/${manifest_file}"

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -99,8 +99,19 @@ pushd /app/vendor/nginx >/dev/null
 tar zcvf "${tempdir}/${nginx_filepath}" .
 popd >/dev/null
 
-s3_upload "$S3_BUCKET" "$nginx_filepath" "${STACK}/${nginx_filepath}"
-"$basedir/manifest" nginx
-"$basedir/package-checksum" "nginx-${nginx_version}"
+
+if ! s3_upload "$S3_BUCKET" "$nginx_filepath" "${STACK}/${nginx_filepath}"; then
+	echo "Unable to upload nginx package to Object Storage!" >&2
+fi
+
+if ! "$basedir/manifest" "nginx"; then
+	echo "Unable to generate/upload manifest for nginx." >&2
+	echo "Something's wrong and needs to be fixed." >&2
+fi
+
+if ! "$basedir/package-checksum" "nginx-${nginx_version}"; then
+	echo "Unable to generate checksums for nginx." >&2
+	echo "Something's wrong and needs to be fixed." >&2
+fi
 
 status "Done building Nginx package!"


### PR DESCRIPTION
Update the `manifest` and `package_nginx` scripts following the recent switch to `awscli`.
- Makes sure manifest file are correctly generated;
- Adds some checks.

This should avoid situations where we upload empty manifests to object storage, which cause fatal errors.