### PR TITLE
fix(packaging): add dependendy to libpcre3-dev

### DIFF
--- a/support/package_nginx
+++ b/support/package_nginx
@@ -26,7 +26,9 @@ zlib_version="$default_zlib_version"
 
 validate_env
 
-which aws >/dev/null || apt-get install awscli
+# Required dependencies:
+apt install --yes \
+	libpcre3-dev
 
 export PATH=${basedir}/../vendor/bin:$PATH
 


### PR DESCRIPTION
- Allows to call package_nginx without calling package_modsecurity first.
- `awscli` is shipped with the stack.