### PR TITLE
chore(zlib): update zlib to 1.3.1.2

### DIFF
--- a/config/versions.sh
+++ b/config/versions.sh
@@ -1,4 +1,4 @@
-default_zlib_version="1.3.1"
+default_zlib_version="1.3.1.2"
 default_nginx_version="1.29.3"
 default_modsecurity_version="3.0.14"
 default_modsecurity_nginx_version="1.0.4"


### PR DESCRIPTION
Files have been uploaded to Object Storage for both `scalingo-22` and `scalingo-24`.

Fix #123 