### PR TITLE
fix(packaging): add dependency to libssl-dev

### DIFF
--- a/support/package_nginx
+++ b/support/package_nginx
@@ -28,7 +28,8 @@ validate_env
 
 # Required dependencies:
 apt install --yes \
-	libpcre3-dev
+	libpcre3-dev \
+	libssl-dev
 
 export PATH=${basedir}/../vendor/bin:$PATH
 


### PR DESCRIPTION
`libssl-dev` is required to compile the `-minimal` stacks.